### PR TITLE
hacker theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,3 @@
-remote_theme: pages-themes/midnight@v0.2.0
+remote_theme: pages-themes/hacker@v0.2.0
 plugins:
   - jekyll-remote-theme # add this line to the plugins list if you already have one


### PR DESCRIPTION
This pull request makes a small update to the documentation site configuration by switching the Jekyll remote theme from `midnight` to `hacker`.